### PR TITLE
Remove untypedPointer from CTFE Function struct

### DIFF
--- a/source/mirror/ctfe.d
+++ b/source/mirror/ctfe.d
@@ -68,7 +68,6 @@ Module module_(string moduleName)() {
 
         enum toFunction = Function(
             moduleName,
-            &F.symbol,
             F.index,
             F.identifier,
             Type(ReturnType!(F.symbol).stringof),
@@ -163,7 +162,6 @@ struct OverloadSet {
 /// A function
 struct Function {
     string moduleName;
-    void *untypedPointer;
     int overloadIndex;
     string identifier;
     Type returnType;
@@ -197,7 +195,7 @@ struct Function {
         return moduleName ~ "." ~ identifier;
     }
 
-    string pointerMixin_() @safe pure nothrow const {
+    string pointerMixin() @safe pure nothrow const {
         import std.conv: text;
         return text(`&__traits(getOverloads, `, moduleName, `, "`, identifier, `")[`, overloadIndex, `]`);
     }
@@ -232,33 +230,3 @@ struct Parameter {
 // * Unit tests
 // * Class hierachies
 // * Aliases?
-
-
-string pointerMixin(in string varName) @safe pure {
-    return `mixin(pointerMixin(` ~ varName ~ `, "` ~ varName ~ `"))`;
-}
-
-
-string pointerMixin(in Function function_, in string functionVarName) @safe pure {
-    import std.conv: text;
-    return `() @trusted { return ` ~ function_.pointerCastMixin ~ functionVarName ~ `.untypedPointer; }()`;
-}
-
-
-string pointerCastMixin(in Function function_) @safe pure {
-    import std.conv: text;
-    return text(`cast(`, function_.pointerSignature, `) `);
-}
-
-
-string pointerSignature(in Function function_) @safe pure {
-    import std.conv: text;
-    import std.algorithm: map, joiner;
-
-    return text(
-        function_.returnType,
-        " function(",
-        function_.parameters.map!(p => p.type.text).joiner(", "),
-        ")",
-    );
-}

--- a/source/mirror/ctfe.d
+++ b/source/mirror/ctfe.d
@@ -175,6 +175,11 @@ struct Function {
             argTexts.map!text.join(`, `),
             `)`);
     }
+
+    string fullyQualifiedName() @safe pure nothrow const {
+        return moduleName ~ "." ~ identifier;
+    }
+
 }
 
 

--- a/tests/ut/ctfe/functions.d
+++ b/tests/ut/ctfe/functions.d
@@ -4,6 +4,7 @@ module ut.ctfe.functions;
 import ut.ctfe;
 
 
+
 @("callMixin.add1")
 unittest {
     import std.traits: Unqual;
@@ -23,29 +24,28 @@ unittest {
 }
 
 
-@("pointerMixin_.byOverload.add1.0")
+@("pointer.byOverload.add1.0")
 unittest {
     enum mod = module_!"modules.functions";
     enum add1 = mod.functionsByOverload[0];
 
     mixin(add1.importMixin);
 
-    auto ptr = mixin(add1.pointerMixin_);
+    auto ptr = pointer!add1;
     static assert(is(typeof(ptr) == int function(int, int)));
 
     ptr(1, 2).should == 4;
     ptr(2, 3).should == 6;
 }
 
-
-@("pointerMixin_.byOverload.add1.1")
+@("pointer.byOverload.add1.1")
 unittest {
     enum mod = module_!"modules.functions";
     enum add1 = mod.functionsByOverload[1];
 
     mixin(add1.importMixin);
 
-    auto ptr = mixin(add1.pointerMixin_);
+    auto ptr = pointer!add1;
     static assert(is(typeof(ptr) == double function(double, double)));
 
     ptr(1.0, 2.0).should == 4.0;
@@ -53,7 +53,7 @@ unittest {
 }
 
 
-@("pointerMixin_.bySymbol.add1")
+@("pointer.bySymbol.add1")
 unittest {
     enum mod = module_!"modules.functions";
     enum add1 = mod.functionsBySymbol[0];
@@ -63,19 +63,19 @@ unittest {
 
     mixin(add1Int.importMixin);
 
-    auto ptrInt = mixin(add1Int.pointerMixin_);
+    auto ptrInt = pointer!add1Int;
     static assert(is(typeof(ptrInt) == int function(int, int)));
     ptrInt(1, 2).should == 4;
     ptrInt(2, 3).should == 6;
 
-    auto ptrDouble = mixin(add1Double.pointerMixin_);
+    auto ptrDouble = pointer!add1Double;
     static assert(is(typeof(ptrDouble) == double function(double, double)));
     ptrDouble(1.0, 2.0).should == 4.0;
     ptrDouble(2.0, 3.0).should == 6.0;
 }
 
 
-@("pointerMixin_.byOverload.withDefault")
+@("pointer.byOverload.withDefault")
 unittest {
     static import modules.functions;
 
@@ -83,7 +83,7 @@ unittest {
     enum withDefault = mod.functionsByOverload[2];
     static assert(withDefault.identifier == "withDefault");
 
-    auto ptr = mixin(withDefault.pointerMixin_);
+    auto ptr = pointer!withDefault;
     (ptr is &modules.functions.withDefault).should == true;
 
     ptr(1.1, 2.2).should ~ 3.3;
@@ -91,40 +91,71 @@ unittest {
 }
 
 
-@("pointerMixin.add1")
+@("pointerMixin.byOverload.add1.0")
 unittest {
-    static import modules.functions;
-    import std.traits: Unqual;
-
     enum mod = module_!"modules.functions";
     enum add1 = mod.functionsByOverload[0];
-    static assert(add1.identifier == "add1");
 
-    auto add1Ptr = mixin(pointerMixin("add1"));
-    static assert(is(Unqual!(typeof(add1Ptr)) ==
-                     typeof(&__traits(getOverloads, modules.functions, "add1")[0])));
+    mixin(add1.importMixin);
 
-    add1Ptr(1, 2).should == 4;
-    add1Ptr(2, 3).should == 6;
+    auto ptr = mixin(add1.pointerMixin);
+    static assert(is(typeof(ptr) == int function(int, int)));
+
+    ptr(1, 2).should == 4;
+    ptr(2, 3).should == 6;
 }
 
 
-@("pointerMixin.withDefault")
+@("pointerMixin.byOverload.add1.1")
+unittest {
+    enum mod = module_!"modules.functions";
+    enum add1 = mod.functionsByOverload[1];
+
+    mixin(add1.importMixin);
+
+    auto ptr = mixin(add1.pointerMixin);
+    static assert(is(typeof(ptr) == double function(double, double)));
+
+    ptr(1.0, 2.0).should == 4.0;
+    ptr(2.0, 3.0).should == 6.0;
+}
+
+
+@("pointerMixin.bySymbol.add1")
+unittest {
+    enum mod = module_!"modules.functions";
+    enum add1 = mod.functionsBySymbol[0];
+
+    enum add1Int = add1.overloads[0];
+    enum add1Double = add1.overloads[1];
+
+    mixin(add1Int.importMixin);
+
+    auto ptrInt = mixin(add1Int.pointerMixin);
+    static assert(is(typeof(ptrInt) == int function(int, int)));
+    ptrInt(1, 2).should == 4;
+    ptrInt(2, 3).should == 6;
+
+    auto ptrDouble = mixin(add1Double.pointerMixin);
+    static assert(is(typeof(ptrDouble) == double function(double, double)));
+    ptrDouble(1.0, 2.0).should == 4.0;
+    ptrDouble(2.0, 3.0).should == 6.0;
+}
+
+
+@("pointerMixin.byOverload.withDefault")
 unittest {
     static import modules.functions;
-    import std.traits: Unqual;
 
     enum mod = module_!"modules.functions";
     enum withDefault = mod.functionsByOverload[2];
     static assert(withDefault.identifier == "withDefault");
 
-    auto withDefaultPtr = mixin(pointerMixin("withDefault"));
-    static assert(is(Unqual!(typeof(withDefaultPtr)) == typeof(&modules.functions.withDefault)));
+    auto ptr = mixin(withDefault.pointerMixin);
+    (ptr is &modules.functions.withDefault).should == true;
 
-    withDefaultPtr(1.1, 2.2).should ~ 3.3;
-    // FIXME
-    // pointerSignature doesn't take default arguments or function attributes into account
-    // withDefaultPtr(1.1).should ~ 34.4;
+    ptr(1.1, 2.2).should ~ 3.3;
+    ptr(1.1).should ~ 34.4;
 }
 
 
@@ -138,7 +169,6 @@ unittest {
         [
             Function(
                 "modules.functions",
-                &__traits(getOverloads, modules.functions, "add1")[0],
                 0,
                 "add1",
                 Type("int"),
@@ -149,7 +179,6 @@ unittest {
             ),
             Function(
                 "modules.functions",
-                &__traits(getOverloads, modules.functions, "add1")[1],
                 1,
                 "add1",
                 Type("double"),
@@ -160,7 +189,6 @@ unittest {
             ),
             Function(
                 "modules.functions",
-                &modules.functions.withDefault,
                 0,
                 "withDefault",
                 Type("double"),
@@ -171,7 +199,6 @@ unittest {
             ),
             Function(
                 "modules.functions",
-                &modules.functions.storageClasses,
                 0,
                 "storageClasses",
                 Type("void"),
@@ -185,7 +212,6 @@ unittest {
             ),
             Function(
                 "modules.functions",
-                &modules.functions.exportedFunc,
                 0,
                 "exportedFunc",
                 Type("void"),
@@ -193,7 +219,6 @@ unittest {
             ),
             Function(
                 "modules.functions",
-                &modules.functions.externC,
                 0,
                 "externC",
                 Type("void"),
@@ -201,7 +226,6 @@ unittest {
             ),
             Function(
                 "modules.functions",
-                &modules.functions.externCpp,
                 0,
                 "externCpp",
                 Type("void"),
@@ -209,7 +233,6 @@ unittest {
             ),
             Function(
                 "modules.functions",
-                &modules.functions.identityInt,
                 0,
                 "identityInt",
                 Type("int"),
@@ -217,7 +240,6 @@ unittest {
             ),
             Function(
                 "modules.functions",
-                &modules.functions.voldermort,
                 0,
                 "voldermort",
                 Type("Voldermort"),
@@ -225,7 +247,6 @@ unittest {
             ),
             Function(
                 "modules.functions",
-                &modules.functions.voldermortArray,
                 0,
                 "voldermortArray",
                 Type("DasVoldermort[]"),
@@ -233,7 +254,6 @@ unittest {
             ),
             Function(
                 "modules.functions",
-                &modules.functions.concatFoo,
                 0,
                 "concatFoo",
                 Type("string"),
@@ -261,7 +281,6 @@ unittest {
                 [
                     Function(
                         "modules.functions",
-                        &__traits(getOverloads, modules.functions, "add1")[0],
                         0,
                         "add1",
                         Type("int"),
@@ -272,7 +291,6 @@ unittest {
                     ),
                     Function(
                         "modules.functions",
-                        &__traits(getOverloads, modules.functions, "add1")[1],
                         1,
                         "add1",
                         Type("double"),
@@ -288,7 +306,6 @@ unittest {
                 [
                     Function(
                         "modules.functions",
-                        &modules.functions.withDefault,
                         0,
                         "withDefault",
                         Type("double"),
@@ -304,7 +321,6 @@ unittest {
                 [
                     Function(
                         "modules.functions",
-                        &modules.functions.storageClasses,
                         0,
                         "storageClasses",
                         Type("void"),
@@ -323,7 +339,6 @@ unittest {
                 [
                     Function(
                         "modules.functions",
-                        &modules.functions.exportedFunc,
                         0,
                         "exportedFunc",
                         Type("void"),
@@ -336,7 +351,6 @@ unittest {
                 [
                     Function(
                         "modules.functions",
-                        &modules.functions.externC,
                         0,
                         "externC",
                         Type("void"),
@@ -349,7 +363,6 @@ unittest {
                 [
                     Function(
                         "modules.functions",
-                        &modules.functions.externCpp,
                         0,
                         "externCpp",
                         Type("void"),
@@ -362,7 +375,6 @@ unittest {
                 [
                     Function(
                         "modules.functions",
-                        &modules.functions.identityInt,
                         0,
                         "identityInt",
                         Type("int"),
@@ -375,7 +387,6 @@ unittest {
                 [
                     Function(
                         "modules.functions",
-                        &modules.functions.voldermort,
                         0,
                         "voldermort",
                         Type("Voldermort"),
@@ -388,7 +399,6 @@ unittest {
                 [
                     Function(
                         "modules.functions",
-                        &modules.functions.voldermortArray,
                         0,
                         "voldermortArray",
                         Type("DasVoldermort[]"),
@@ -401,7 +411,6 @@ unittest {
                 [
                     Function(
                         "modules.functions",
-                        &modules.functions.concatFoo,
                         0,
                         "concatFoo",
                         Type("string"),

--- a/tests/ut/ctfe/functions.d
+++ b/tests/ut/ctfe/functions.d
@@ -4,7 +4,7 @@ module ut.ctfe.functions;
 import ut.ctfe;
 
 
-@("call.add1")
+@("callMixin.add1")
 unittest {
     import std.traits: Unqual;
 
@@ -20,6 +20,58 @@ unittest {
     mixin(add1.callMixin(1, 2)).should == 4;
     auto arg = 2;
     mixin(add1.callMixin("arg", 2)).should == 5;
+}
+
+
+@("pointerMixin_.byOverload.add1.0")
+unittest {
+    enum mod = module_!"modules.functions";
+    enum add1 = mod.functionsByOverload[0];
+
+    mixin(add1.importMixin);
+
+    auto ptr = mixin(add1.pointerMixin_);
+    static assert(is(typeof(ptr) == int function(int, int)));
+
+    ptr(1, 2).should == 4;
+    ptr(2, 3).should == 6;
+}
+
+
+@("pointerMixin_.byOverload.add1.1")
+unittest {
+    enum mod = module_!"modules.functions";
+    enum add1 = mod.functionsByOverload[1];
+
+    mixin(add1.importMixin);
+
+    auto ptr = mixin(add1.pointerMixin_);
+    static assert(is(typeof(ptr) == double function(double, double)));
+
+    ptr(1.0, 2.0).should == 4.0;
+    ptr(2.0, 3.0).should == 6.0;
+}
+
+
+@("pointerMixin_.bySymbol.add1")
+unittest {
+    enum mod = module_!"modules.functions";
+    enum add1 = mod.functionsBySymbol[0];
+
+    enum add1Int = add1.overloads[0];
+    enum add1Double = add1.overloads[1];
+
+    mixin(add1Int.importMixin);
+
+    auto ptrInt = mixin(add1Int.pointerMixin_);
+    static assert(is(typeof(ptrInt) == int function(int, int)));
+    ptrInt(1, 2).should == 4;
+    ptrInt(2, 3).should == 6;
+
+    auto ptrDouble = mixin(add1Double.pointerMixin_);
+    static assert(is(typeof(ptrDouble) == double function(double, double)));
+    ptrDouble(1.0, 2.0).should == 4.0;
+    ptrDouble(2.0, 3.0).should == 6.0;
 }
 
 
@@ -71,6 +123,7 @@ unittest {
             Function(
                 "modules.functions",
                 &__traits(getOverloads, modules.functions, "add1")[0],
+                0,
                 "add1",
                 Type("int"),
                 [
@@ -81,6 +134,7 @@ unittest {
             Function(
                 "modules.functions",
                 &__traits(getOverloads, modules.functions, "add1")[1],
+                1,
                 "add1",
                 Type("double"),
                 [
@@ -91,6 +145,7 @@ unittest {
             Function(
                 "modules.functions",
                 &modules.functions.withDefault,
+                0,
                 "withDefault",
                 Type("double"),
                 [
@@ -101,6 +156,7 @@ unittest {
             Function(
                 "modules.functions",
                 &modules.functions.storageClasses,
+                0,
                 "storageClasses",
                 Type("void"),
                 [
@@ -114,6 +170,7 @@ unittest {
             Function(
                 "modules.functions",
                 &modules.functions.exportedFunc,
+                0,
                 "exportedFunc",
                 Type("void"),
                 [],
@@ -121,6 +178,7 @@ unittest {
             Function(
                 "modules.functions",
                 &modules.functions.externC,
+                0,
                 "externC",
                 Type("void"),
                 [],
@@ -128,6 +186,7 @@ unittest {
             Function(
                 "modules.functions",
                 &modules.functions.externCpp,
+                0,
                 "externCpp",
                 Type("void"),
                 [],
@@ -135,6 +194,7 @@ unittest {
             Function(
                 "modules.functions",
                 &modules.functions.identityInt,
+                0,
                 "identityInt",
                 Type("int"),
                 [Parameter("int", "x", "", PSC.none)],
@@ -142,6 +202,7 @@ unittest {
             Function(
                 "modules.functions",
                 &modules.functions.voldermort,
+                0,
                 "voldermort",
                 Type("Voldermort"),
                 [Parameter("int", "i", "", PSC.none)],
@@ -149,6 +210,7 @@ unittest {
             Function(
                 "modules.functions",
                 &modules.functions.voldermortArray,
+                0,
                 "voldermortArray",
                 Type("DasVoldermort[]"),
                 [Parameter("int", "i", "", PSC.none)],
@@ -156,6 +218,7 @@ unittest {
             Function(
                 "modules.functions",
                 &modules.functions.concatFoo,
+                0,
                 "concatFoo",
                 Type("string"),
                 [
@@ -183,6 +246,7 @@ unittest {
                     Function(
                         "modules.functions",
                         &__traits(getOverloads, modules.functions, "add1")[0],
+                        0,
                         "add1",
                         Type("int"),
                         [
@@ -193,6 +257,7 @@ unittest {
                     Function(
                         "modules.functions",
                         &__traits(getOverloads, modules.functions, "add1")[1],
+                        1,
                         "add1",
                         Type("double"),
                         [
@@ -208,6 +273,7 @@ unittest {
                     Function(
                         "modules.functions",
                         &modules.functions.withDefault,
+                        0,
                         "withDefault",
                         Type("double"),
                         [
@@ -223,6 +289,7 @@ unittest {
                     Function(
                         "modules.functions",
                         &modules.functions.storageClasses,
+                        0,
                         "storageClasses",
                         Type("void"),
                         [
@@ -241,6 +308,7 @@ unittest {
                     Function(
                         "modules.functions",
                         &modules.functions.exportedFunc,
+                        0,
                         "exportedFunc",
                         Type("void"),
                         [],
@@ -253,6 +321,7 @@ unittest {
                     Function(
                         "modules.functions",
                         &modules.functions.externC,
+                        0,
                         "externC",
                         Type("void"),
                         [],
@@ -265,6 +334,7 @@ unittest {
                     Function(
                         "modules.functions",
                         &modules.functions.externCpp,
+                        0,
                         "externCpp",
                         Type("void"),
                         [],
@@ -277,6 +347,7 @@ unittest {
                     Function(
                         "modules.functions",
                         &modules.functions.identityInt,
+                        0,
                         "identityInt",
                         Type("int"),
                         [Parameter("int", "x", "", PSC.none)],
@@ -289,6 +360,7 @@ unittest {
                     Function(
                         "modules.functions",
                         &modules.functions.voldermort,
+                        0,
                         "voldermort",
                         Type("Voldermort"),
                         [Parameter("int", "i", "", PSC.none)],
@@ -301,6 +373,7 @@ unittest {
                     Function(
                         "modules.functions",
                         &modules.functions.voldermortArray,
+                        0,
                         "voldermortArray",
                         Type("DasVoldermort[]"),
                         [Parameter("int", "i", "", PSC.none)],
@@ -313,6 +386,7 @@ unittest {
                     Function(
                         "modules.functions",
                         &modules.functions.concatFoo,
+                        0,
                         "concatFoo",
                         Type("string"),
                         [

--- a/tests/ut/ctfe/functions.d
+++ b/tests/ut/ctfe/functions.d
@@ -12,8 +12,10 @@ unittest {
     enum add1 = mod.functionsByOverload[0];
 
     mixin(add1.importMixin);
-    mixin(mod.identifier, `.`, add1.identifier, `(1, 2)`).should == 4;
-    mixin(mod.identifier, `.`, add1.identifier, `(2, 3)`).should == 6;
+
+    mixin(add1.fullyQualifiedName, `(1, 2)`).should == 4;
+    mixin(add1.fullyQualifiedName, `(2, 3)`).should == 6;
+
     // or, easier...
     mixin(add1.callMixin(1, 2)).should == 4;
     auto arg = 2;

--- a/tests/ut/ctfe/functions.d
+++ b/tests/ut/ctfe/functions.d
@@ -75,6 +75,22 @@ unittest {
 }
 
 
+@("pointerMixin_.byOverload.withDefault")
+unittest {
+    static import modules.functions;
+
+    enum mod = module_!"modules.functions";
+    enum withDefault = mod.functionsByOverload[2];
+    static assert(withDefault.identifier == "withDefault");
+
+    auto ptr = mixin(withDefault.pointerMixin_);
+    (ptr is &modules.functions.withDefault).should == true;
+
+    ptr(1.1, 2.2).should ~ 3.3;
+    ptr(1.1).should ~ 34.4;
+}
+
+
 @("pointerMixin.add1")
 unittest {
     static import modules.functions;

--- a/tests/ut/meta/functions.d
+++ b/tests/ut/meta/functions.d
@@ -43,7 +43,7 @@ import std.meta: AliasSeq;
 
     alias expected = AliasSeq!(
         FunctionOverload!(add1Int, Protection.public_, Linkage.D),
-        FunctionOverload!(add1Double, Protection.public_, Linkage.D),
+        FunctionOverload!(add1Double, Protection.public_, Linkage.D, "add1", modules.functions, 1),
         FunctionOverload!(withDefault, Protection.public_, Linkage.D),
         FunctionOverload!(storageClasses, Protection.public_, Linkage.D),
         FunctionOverload!(exportedFunc, Protection.export_, Linkage.D),


### PR DESCRIPTION
It prevented passing `Function` instances as template parameters.