### PR TITLE
Fix compilation with D 2.098

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019]
-        dc: [dmd-2.097.2, ldc-1.27.1]
+        dc: [dmd-2.097.2, ldc-1.27.1, dmd-beta, ldc-beta]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/source/mirror/rtti.d
+++ b/source/mirror/rtti.d
@@ -10,7 +10,7 @@ module mirror.rtti;
  */
 mixin template typesVar(alias symbol, T...) {
     shared static this() nothrow {
-        symbol = types!T;
+        symbol = cast(typeof(symbol)) types!T;
     }
 }
 
@@ -147,11 +147,11 @@ abstract class Field {
     import mirror.trait_enums: Protection;
     import std.variant: Variant;
 
-    immutable RuntimeTypeInfo type;
+    const RuntimeTypeInfo type;
     immutable string identifier;
     immutable Protection protection;
 
-    this(immutable RuntimeTypeInfo type, string identifier, in Protection protection) @safe pure scope {
+    this(const RuntimeTypeInfo type, string identifier, in Protection protection) @safe pure scope {
         this.type = type;
         this.identifier = identifier;
         this.protection = protection;
@@ -254,9 +254,9 @@ abstract class Method {
     }
 
     immutable string identifier;
-    immutable RuntimeTypeInfo type;
+    const RuntimeTypeInfo type;
 
-    this(string identifier, immutable RuntimeTypeInfo type) @safe @nogc pure scope const {
+    this(string identifier, const RuntimeTypeInfo type) @safe @nogc pure scope const {
         this.identifier = identifier;
         this.type = type;
     }
@@ -295,8 +295,8 @@ abstract class Method {
     abstract bool isOverride() @safe @nogc pure scope const;
     abstract bool isStatic() @safe @nogc pure scope const;
     abstract bool isSafe() @safe @nogc pure scope const;
-    abstract RuntimeTypeInfo returnType() @safe pure scope const;
-    abstract RuntimeTypeInfo[] parameters() @safe pure scope const;
+    abstract RuntimeTypeInfo returnType() @safe scope const;
+    abstract RuntimeTypeInfo[] parameters() @safe scope const;
     abstract string reprImpl() @safe pure scope const;
     abstract Variant callImpl(TypeQualifier objQualifier, inout Object obj, Variant[] args) const;
 }
@@ -377,12 +377,12 @@ class MethodImpl(alias F): Method {
         return arity!F;
     }
 
-    override RuntimeTypeInfo returnType() @safe pure scope const {
+    override RuntimeTypeInfo returnType() @safe scope const {
         import std.traits: ReturnType;
         return runtimeTypeInfo!(ReturnType!F);
     }
 
-    override RuntimeTypeInfo[] parameters() @safe pure scope const {
+    override RuntimeTypeInfo[] parameters() @safe scope const {
         import std.traits: Parameters;
 
         RuntimeTypeInfo[] ret;

--- a/source/mirror/rtti.d
+++ b/source/mirror/rtti.d
@@ -77,7 +77,7 @@ struct Types {
         return rtti(typeid(obj));
     }
 
-    inout(RuntimeTypeInfo) rtti(scope TypeInfo typeInfo) @safe pure scope inout {
+    inout(RuntimeTypeInfo) rtti(scope TypeInfo typeInfo) @safe scope inout {
         scope ptr = typeInfo in _typeToInfo;
 
         if(ptr is null) {

--- a/tests/ut/ctfe/reflection/types.d
+++ b/tests/ut/ctfe/reflection/types.d
@@ -93,7 +93,7 @@ import ut.ctfe.reflection;
 @("fields.String")
 @safe pure unittest {
     enum mod = module_!"modules.types";
-    immutable string_ = mod.aggregates[0];
+    auto string_ = mod.aggregates[0];
     string_.fields.should == [
         Variable("string", "value"),
     ];
@@ -104,7 +104,7 @@ import ut.ctfe.reflection;
 @safe pure unittest {
     import std.algorithm: find;
     enum mod = module_!"modules.types";
-    const point = mod.aggregates[].find!(a => a.identifier == "modules.types.Point")[0];
+    auto point = mod.aggregates[].find!(a => a.identifier == "modules.types.Point")[0];
     point.fields.should == [
         Variable("double", "x"),
         Variable("double", "y"),

--- a/tests/ut/rtti/any.d
+++ b/tests/ut/rtti/any.d
@@ -6,12 +6,12 @@ import mirror.rtti;
 
 
 @("types.int")
-@safe pure unittest {
+@safe unittest {
     auto extended = types!int;
 }
 
 @("rtti.null.object")
-@safe pure unittest {
+@safe unittest {
     static class Class {}
     Object o;
     Class c;
@@ -24,7 +24,7 @@ import mirror.rtti;
 
 
 @("rtti.unregistered")
-@safe pure unittest {
+@safe unittest {
     static class Class {}
     enum testName = __traits(identifier, __traits(parent, {}));
     enum prefix = __MODULE__ ~ "." ~ testName ~ ".";
@@ -39,7 +39,7 @@ import mirror.rtti;
 
 
 @("typesVar")
-@safe pure unittest {
+@safe unittest {
 
     static struct Namespace {
         static immutable mirror.rtti.Types _types;

--- a/tests/ut/rtti/oop.d
+++ b/tests/ut/rtti/oop.d
@@ -6,7 +6,7 @@ import mirror.rtti;
 
 
 @("name")
-@safe pure unittest {
+@safe unittest {
 
     static abstract class Abstract {
         string getName() @safe pure nothrow scope const;
@@ -96,7 +96,7 @@ private void shouldEqual(
 
 
 @("fields.type.0")
-@safe pure unittest {
+@safe unittest {
     import std.algorithm: map;
 
     static abstract class Abstract {}
@@ -114,7 +114,7 @@ private void shouldEqual(
 
 
 @("fields.id.0")
-@safe pure unittest {
+@safe unittest {
     import std.algorithm: map;
 
     static abstract class Abstract {}
@@ -184,7 +184,7 @@ private void shouldEqual(
 
 
 @("fields.type.1")
-@safe pure unittest {
+@safe unittest {
 
     import std.algorithm: map;
 
@@ -210,7 +210,7 @@ private void shouldEqual(
 
 
 @("fields.id.1")
-@safe pure unittest {
+@safe unittest {
 
     import std.algorithm: map;
 
@@ -315,7 +315,7 @@ private void shouldEqual(
 
 
 @("toString.Int")
-@safe pure unittest {
+@safe unittest {
 
     static class Int {
         int i;
@@ -345,7 +345,7 @@ private void shouldEqual(
 }
 
 @("toString.interface")
-@safe pure unittest {
+@safe unittest {
 
     static interface Interface {}
     static class Class: Interface {}
@@ -360,7 +360,7 @@ private void shouldEqual(
 
 
 @("methods.toString")
-@safe pure unittest {
+@safe unittest {
 
     import std.algorithm.iteration: map;
 
@@ -386,7 +386,7 @@ private void shouldEqual(
 
 
 @("methods.byName")
-@safe pure unittest {
+@safe unittest {
 
     static class Class {
         void foo() {}
@@ -487,7 +487,7 @@ private void shouldEqual(
 
 
 @("methods.traits")
-@safe pure unittest {
+@safe unittest {
 
     static abstract class Abstract {
         abstract void lefunc();


### PR DESCRIPTION
`TypeInfo.toString()` isn't pure anymore - see https://github.com/dlang/druntime/blob/v2.098.0-beta.2/changelog/UniqueTypeInfoNames.md.